### PR TITLE
添加推送到飞书多维表格的代码

### DIFF
--- a/arxiv_crawler.py
+++ b/arxiv_crawler.py
@@ -16,6 +16,7 @@ class ArxivScraper(object):
         self,
         date_from,
         date_until,
+        subject_list=["computer_science", "physics", "economics", "eess", "mathematics", "q_biology", "q_finance", "statistics"],
         category_blacklist=[],
         category_whitelist=["cs.CV", "cs.AI", "cs.LG", "cs.CL", "cs.IR", "cs.MA"],
         optional_keywords=["LLM", "LLMs", "language model", "language models", "multimodal", "finetuning", "GPT"],
@@ -32,6 +33,7 @@ class ArxivScraper(object):
         Args:
             date_from (str): 开始日期(含当天)
             date_until (str): 结束日期(含当天)
+            subject_list (list, optional): 领域. Defaults to ["computer_science", "physics", "economics", "eess", "mathematics", "q_biology", "q_finance", "statistics"]
             category_blacklist (list, optional): 黑名单. Defaults to [].
             category_whitelist (list, optional): 白名单. Defaults to ["cs.CV", "cs.AI", "cs.LG", "cs.CL", "cs.IR", "cs.MA"].
             optional_keywords (list, optional): 关键词, 各词之间关系为OR, 在标题/摘要中至少要出现一个关键词才会被爬取.
@@ -48,6 +50,7 @@ class ArxivScraper(object):
         # 由于arxiv的奇怪机制，每个月的第一天公布的文章总会被视作上个月的文章, 所以需要将月初文章的首次公布日期往后推一天
         self.fisrt_announced_date = next_arxiv_update_day(next_arxiv_update_day(self.search_from_date) + timedelta(days=1))
 
+        self.subject_list = subject_list
         self.category_blacklist = category_blacklist  # used as metadata
         self.category_whitelist = category_whitelist  # used as metadata
         self.optional_keywords = [kw.replace(" ", "+") for kw in optional_keywords]  # url转义
@@ -87,9 +90,10 @@ class ArxivScraper(object):
         )
         date_from = self.search_from_date.strftime("%Y-%m")
         date_until = self.search_until_date.strftime("%Y-%m")
+        subjects_query = '&classification-{}=y'.format('=y&classification-'.join(self.subject_list))
         return (
             f"https://arxiv.org/search/advanced?advanced={kwargs}"
-            f"&classification-computer_science=y&classification-physics_archives=all&"
+            f"{subjects_query}&classification-physics_archives=all&"
             f"classification-include_cross_list=include&"
             f"date-year=&date-filter_by=date_range&date-from_date={date_from}&date-to_date={date_until}&"
             f"date-date_type={self.filt_date_by}&abstracts=show&size={self.step}&order={self.order}&start={start}"

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,37 @@
+Feishu:
+  Enable: true
+  App_ID: cli_a7eea4232xxxxxxx
+  App_Secret: 8RTvqR5KcoioI8fjvxvUCDbQY3NIKhaA
+  User_ID: 1b2g65ag
+  include_filtered: false
+Subject:
+  - computer_science
+  # - physics
+  # - economics
+  # - eess
+  # - mathematics
+  # - q_biology
+  # - q_finance
+  # - statistics
+Categories:
+  BlackList: null
+  WhiteList:
+    - cs.CV
+    - cs.AI
+    - cs.LG
+    - cs.CL
+    - cs.IR
+    - cs.MA
+Keywords:
+  - LLM
+  - LLMs
+  - language model
+  - language models
+  - multimodal
+  - finetuning
+  - GPT
+Tans_to: zh-CN
+Proxy:
+  Enable: true
+  Address: 'http://127.0.0.1:7890'
+Output_Directory: ./output

--- a/main.py
+++ b/main.py
@@ -1,0 +1,47 @@
+import yaml
+from datetime import date, timedelta
+from arxiv_crawler import ArxivScraper
+from push_to_feishu import Push2Feishu
+import asyncio
+import os
+
+if __name__ == "__main__":
+
+    with open('config.yaml') as f:
+        cfg = yaml.load(f, Loader=yaml.FullLoader)
+
+    # 输出昨天更新的文章
+    yesterday = date.today() - timedelta(days=1)
+
+    categories = cfg['Categories']
+
+    scraper = ArxivScraper(
+        date_from=yesterday.strftime("%Y-%m-%d"),
+        date_until=yesterday.strftime("%Y-%m-%d"),
+        subject_list=cfg['Subject'],
+        category_blacklist=(
+            [] if categories['BlackList'] is None else categories['BlackList']
+        ),
+        category_whitelist=(
+            [] if categories['WhiteList'] is None else categories['WhiteList']
+        ),
+        optional_keywords=cfg['Keywords'],
+        trans_to=cfg['Tans_to'],
+        proxy=None if cfg['Proxy']['Enable'] is False else cfg['Proxy']['Address'],
+    )
+    asyncio.run(scraper.fetch_all())
+    scraper.to_markdown(output_dir=cfg['Output_Directory'], meta=True)
+    scraper.to_csv(
+        output_dir=cfg['Output_Directory'],
+        header=False,
+        csv_config=dict(delimiter="\t"),
+    )
+
+    # 推送到飞书
+    feishu_cfg = cfg['Feishu']
+    if feishu_cfg['Enable'] is True:
+        push = Push2Feishu(feishu_cfg['App_ID'], feishu_cfg['App_Secret'], retry=1)
+        csv_fname = os.path.join(
+            cfg['Output_Directory'], f"{yesterday.strftime('%Y-%m-%d')}.csv"
+        )
+        push.to_feishu(csv_fname, feishu_cfg['User_ID'], feishu_cfg['include_filtered'])

--- a/push_to_feishu.py
+++ b/push_to_feishu.py
@@ -1,0 +1,689 @@
+import requests
+import json
+from rich.console import Console
+import pandas as pd
+import os
+import datetime as dt
+
+
+class Push2Feishu(object):
+    def __init__(self, app_id, app_secret, personal_cfg='personal_cfg.json', retry=3):
+        """
+        飞书机器人创建及获取 app_id, app_secret 参见：
+        https://open.feishu.cn/document/home/develop-a-bot-in-5-minutes/create-an-app
+        """
+        self.app_id = app_id
+        self.app_secret = app_secret
+        self.retry = retry
+        self.personal_cfg_fname = personal_cfg
+        self.personal_cfg = (
+            {}
+            if not os.path.exists(self.personal_cfg_fname)
+            else json.load(open(self.personal_cfg_fname))
+        )
+        self.console = Console()
+        self.token = self.update_tenant_access_token()
+        self.table_fields = json.loads(
+            '''[
+  {
+    "field_name": "Title",
+    "is_primary": true,
+    "property": null,
+    "type": 1,
+    "ui_type": "Text"
+  },
+  {
+    "field_name": "Interest",
+    "is_primary": false,
+    "property": {
+      "options": [
+        {
+          "color": 10,
+          "name": "chosen"
+        },
+        {
+          "color": 33,
+          "name": "CORE"
+        },
+        {
+          "color": 12,
+          "name": "PEER"
+        },
+        {
+          "color": 13,
+          "name": "RELATED"
+        },
+        {
+          "color": 15,
+          "name": "INTERESTING"
+        },
+        {
+          "color": 2,
+          "name": "NORMAL"
+        },
+        {
+          "color": 0,
+          "name": "IRRELEVANT"
+        },
+        {
+          "color": 43,
+          "name": "filtered"
+        }
+      ]
+    },
+    "type": 3,
+    "ui_type": "SingleSelect"
+  },
+  {
+    "field_name": "Title Translated",
+    "is_primary": false,
+    "property": null,
+    "type": 1,
+    "ui_type": "Text"
+  },
+  {
+    "field_name": "Categories",
+    "is_primary": false,
+    "property": {
+      "options": [
+        {
+          "color": 0,
+          "name": "cs.CL"
+        },
+        {
+          "color": 1,
+          "name": "cs.AI"
+        },
+        {
+          "color": 2,
+          "name": "econ.GN"
+        },
+        {
+          "color": 3,
+          "name": "cs.CV"
+        },
+        {
+          "color": 4,
+          "name": "cs.MM"
+        },
+        {
+          "color": 5,
+          "name": "cs.SE"
+        },
+        {
+          "color": 6,
+          "name": "cs.LG"
+        },
+        {
+          "color": 7,
+          "name": "cs.CY"
+        },
+        {
+          "color": 8,
+          "name": "cs.CR"
+        },
+        {
+          "color": 9,
+          "name": "cs.GR"
+        },
+        {
+          "color": 0,
+          "name": "cs.IR"
+        },
+        {
+          "color": 1,
+          "name": "cs.HC"
+        },
+        {
+          "color": 2,
+          "name": "physics.chem-ph"
+        },
+        {
+          "color": 3,
+          "name": "q-bio.BM"
+        },
+        {
+          "color": 4,
+          "name": "cs.RO"
+        },
+        {
+          "color": 5,
+          "name": "eess.SP"
+        },
+        {
+          "color": 6,
+          "name": "cs.SD"
+        },
+        {
+          "color": 7,
+          "name": "eess.AS"
+        },
+        {
+          "color": 8,
+          "name": "cs.DC"
+        },
+        {
+          "color": 9,
+          "name": "cs.PL"
+        },
+        {
+          "color": 0,
+          "name": "cs.MA"
+        },
+        {
+          "color": 1,
+          "name": "cs.NE"
+        },
+        {
+          "color": 2,
+          "name": "cs.SI"
+        },
+        {
+          "color": 1,
+          "name": "Categories"
+        },
+        {
+          "color": 2,
+          "name": "cs.AR"
+        },
+        {
+          "color": 3,
+          "name": "cs.DB"
+        },
+        {
+          "color": 4,
+          "name": "cs.LO"
+        },
+        {
+          "color": 5,
+          "name": "cs.CE"
+        },
+        {
+          "color": 6,
+          "name": "cs.IT"
+        },
+        {
+          "color": 7,
+          "name": "math.OC"
+        },
+        {
+          "color": 8,
+          "name": "stat.ML"
+        },
+        {
+          "color": 9,
+          "name": "q-bio.NC"
+        },
+        {
+          "color": 10,
+          "name": "physics.comp-ph"
+        },
+        {
+          "color": 0,
+          "name": "cond-mat.mtrl-sci"
+        },
+        {
+          "color": 1,
+          "name": "q-fin.CP"
+        },
+        {
+          "color": 2,
+          "name": "cs.ET"
+        },
+        {
+          "color": 3,
+          "name": "cs.SC"
+        },
+        {
+          "color": 4,
+          "name": "q-bio.QM"
+        },
+        {
+          "color": 5,
+          "name": "stat.ME"
+        },
+        {
+          "color": 6,
+          "name": "cond-mat.dis-nn"
+        },
+        {
+          "color": 7,
+          "name": "physics.data-an"
+        },
+        {
+          "color": 8,
+          "name": "math.NA"
+        },
+        {
+          "color": 9,
+          "name": "math.PR"
+        },
+        {
+          "color": 10,
+          "name": "astro-ph.IM"
+        },
+        {
+          "color": 0,
+          "name": "cs.NI"
+        }
+      ]
+    },
+    "type": 4,
+    "ui_type": "MultiSelect"
+  },
+  {
+    "field_name": "Authors",
+    "is_primary": false,
+    "property": null,
+    "type": 1,
+    "ui_type": "Text"
+  },
+  {
+    "field_name": "Arxiv",
+    "is_primary": false,
+    "property": null,
+    "type": 15,
+    "ui_type": "Url"
+  },
+  {
+    "field_name": "PapersCool",
+    "is_primary": false,
+    "property": null,
+    "type": 15,
+    "ui_type": "Url"
+  },
+  {
+    "field_name": "First Submitted Date",
+    "is_primary": false,
+    "property": {
+      "auto_fill": false,
+      "date_formatter": "yyyy/MM/dd"
+    },
+    "type": 5,
+    "ui_type": "DateTime"
+  },
+  {
+    "field_name": "First Announced Date",
+    "is_primary": false,
+    "property": {
+      "auto_fill": false,
+      "date_formatter": "yyyy/MM/dd"
+    },
+    "type": 5,
+    "ui_type": "DateTime"
+  },
+  {
+    "field_name": "Abstract",
+    "is_primary": false,
+    "property": null,
+    "type": 1,
+    "ui_type": "Text"
+  },
+  {
+    "field_name": "Abstract Translated",
+    "is_primary": false,
+    "property": null,
+    "type": 1,
+    "ui_type": "Text"
+  },
+  {
+    "field_name": "Comments",
+    "is_primary": false,
+    "property": null,
+    "type": 1,
+    "ui_type": "Text"
+  },
+  {
+    "field_name": "Note",
+    "is_primary": false,
+    "property": null,
+    "type": 1,
+    "ui_type": "Text"
+  }
+]'''
+        )
+
+    def update_tenant_access_token(self):
+        """
+        获取 tenant_access_token，此数据每30分钟更新一次。为避免失效导致的错误，
+        最好每次请求前都调用此方法获取最新的 token。
+        """
+
+        url = 'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal'
+        headers = {'Content-Type': 'application/json; charset=utf-8'}
+        data = json.dumps({'app_id': self.app_id, 'app_secret': self.app_secret})
+        error = 0
+        # 重试机制
+        while error < self.retry:
+            try:
+                response = requests.post(url, headers=headers, data=data)
+                result = response.json()
+                if result.get('code') != 0:
+                    error += 1
+                    self.console.log(
+                        f'[bold red]Request tenant_access_token failed: {result.get("msg")}'
+                    )
+                    self.console.print_exception()
+                    self.console.log(
+                        f'[bold red]Retrying update_tenant_access_token... {error}/{self.retry}'
+                    )
+                else:
+                    self.token = result.get('tenant_access_token')
+                    return self.token
+            except Exception as e:
+                error += 1
+                self.console.log(
+                    f'[bold red]Request tenant_access_token failed: {str(e)}'
+                )
+                self.console.print_exception()
+                self.console.log(
+                    f'[bold red]Retrying update_tenant_access_token... {error}/{self.retry}'
+                )
+
+    def create_bitable(self, bitable_name, time_zone='Asia/Shanghai'):
+        """
+        创建飞书表格。
+        Ref. https://open.feishu.cn/document/server-docs/docs/bitable-v1/app/create
+        """
+
+        self.update_tenant_access_token()
+        url = 'https://open.feishu.cn/open-apis/bitable/v1/apps'
+        headers = {
+            'Content-Type': 'application/json; charset=utf-8',
+            'Authorization': f'Bearer {self.token}',
+        }
+        data = json.dumps(
+            {'name': bitable_name, 'folder_token': '', 'time_zone': time_zone}
+        )
+        try:
+            response = requests.post(url, headers=headers, data=data)
+            result = response.json()
+            if result.get('code') != 0:
+                self.console.log(
+                    f'[bold red]Create bitable failed: {result.get("msg")}'
+                )
+                self.console.print_exception()
+            else:
+                return result
+        except Exception as e:
+            self.console.log(f'[bold red]Create bitable failed: {str(e)}')
+            self.console.print_exception()
+        return None
+
+    def transfer_owner(self, app_token, new_owner_userid):
+        """
+        转让表格的所有权。
+        飞书应用直接为用户创建文件需要使用 user_access_token，而获取 user_access_token
+        需要配置重定向域名，过于繁琐。这里使用应用创建多维表格，然后将所有权转让给
+        指定用户。
+        """
+        self.update_tenant_access_token()
+        url = f'https://open.feishu.cn/open-apis/drive/v1/permissions/{app_token}/members/transfer_owner?type=bitable&remove_old_owner=false'
+        headers = {
+            'Content-Type': 'application/json; charset=utf-8',
+            'Authorization': f'Bearer {self.token}',
+        }
+        data = json.dumps({'member_type': 'userid', "member_id": new_owner_userid})
+        try:
+            response = requests.post(url, headers=headers, data=data)
+            result = response.json()
+            if result.get('code') != 0:
+                self.console.log(
+                    f'[bold red]Transfer owner failed: {result.get("msg")}'
+                )
+                self.console.print_exception()
+            else:
+                return result
+        except Exception as e:
+            self.console.log(f'[bold red]Transfer owner failed: {str(e)}')
+            self.console.print_exception()
+
+        return None
+
+    def create_kanban(self, app_token, table_id, kanban_name='看板'):
+        '''此函数用于创建 Bitable 中的看板
+        Ref. https://open.feishu.cn/document/server-docs/docs/bitable-v1/app-table-view/create
+        '''
+
+        self.update_tenant_access_token()
+        url = f'https://open.feishu.cn/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views'
+        headers = {
+            'Authorization': f'Bearer {self.token}',
+            'Content-Type': 'application/json; charset=utf-8',
+        }
+        data = json.dumps({'view_name': kanban_name, 'view_type': 'kanban'})
+        try:
+            response = requests.post(url, headers=headers, data=data)
+            result = response.json()
+            if result.get('code') != 0:
+                self.console.log(f'[bold red]Create kanban failed: {result.get("msg")}')
+                self.console.print_exception()
+            else:
+                return result
+        except Exception as e:
+            self.console.log(f'[bold red]Create kanban failed: {str(e)}')
+            self.console.print_exception()
+
+        return None
+
+    def create_table(self, app_token, table_name):
+        '''此函数用于创建 Bitable 中的表格
+        Ref. https://open.feishu.cn/document/server-docs/docs/bitable-v1/app-table/create
+        '''
+        self.update_tenant_access_token()
+        url = f'https://open.feishu.cn/open-apis/bitable/v1/apps/{app_token}/tables'
+        headers = {
+            'Authorization': f'Bearer {self.token}',
+            'Content-Type': 'application/json; charset=utf-8',
+        }
+        data = json.dumps(
+            {
+                'table': {
+                    'name': f'{table_name}',
+                    'default_view_name': '表格',
+                    'fields': self.table_fields,
+                }
+            }
+        )
+        try:
+            response = requests.post(url, headers=headers, data=data)
+            result = response.json()
+            if result.get('code') != 0:
+                self.console.log(f'[bold red]Create table failed: {result.get("msg")}')
+                self.console.print_exception()
+            else:
+                return result
+        except Exception as e:
+            self.console.log(f'[bold red]Create table failed: {str(e)}')
+            self.console.print_exception()
+
+        return None
+
+    def delete_table(self, app_token, table_id):
+        '''此函数用于删除 Bitable 中的文件
+        Ref. https://open.feishu.cn/document/server-docs/docs/drive-v1/file/delete
+        '''
+        self.update_tenant_access_token()
+        url = f'https://open.feishu.cn/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}'
+        headers = {
+            'Authorization': f'Bearer {self.token}',
+            'Content-Type': 'application/json; charset=utf-8',
+        }
+        try:
+            response = requests.delete(url, headers=headers)
+            result = response.json()
+            if result.get('code') != 0:
+                self.console.log(f'[bold red]Delete table failed: {result.get("msg")}')
+                self.console.print_exception()
+            else:
+                return result
+        except Exception as e:
+            self.console.log(f'[bold red]Delete table failed: {str(e)}')
+            self.console.print_exception()
+
+    def list_bitable_tables(self, app_token):
+        '''此函数用于列出 Bitable 中的表格
+        Ref. https://open.feishu.cn/document/server-docs/docs/bitable-v1/app-table/list
+        '''
+        self.update_tenant_access_token()
+        url = f'https://open.feishu.cn/open-apis/bitable/v1/apps/{app_token}/tables?page_size=100'
+        headers = {
+            'Authorization': f'Bearer {self.token}',
+            'Content-Type': 'application/json; charset=utf-8',
+        }
+        try:
+            response = requests.get(url, headers=headers)
+            result = response.json()
+            if result.get('code') != 0:
+                self.console.log(f'[bold red]List table failed: {result.get("msg")}')
+                self.console.print_exception()
+            else:
+                return result
+        except Exception as e:
+            self.console.log(f'[bold red]List table failed: {str(e)}')
+            self.console.print_exception()
+
+        return None
+
+    @staticmethod
+    def format_data(csv_name, include_filtered=False):
+        '''
+        此函数用于将 CSV 数据转换为 Bitable 表格可以接受的 json 数据
+        '''
+        content = pd.read_csv(
+            csv_name,
+            encoding='utf-8',
+            header=None,
+            names=[
+                'Title',
+                'Interest',
+                'Title Translated',
+                'Categories',
+                'Authors',
+                'Arxiv',
+                'PapersCool',
+                'First Submitted Date',
+                'First Announced Date',
+                'Abstract',
+                'Abstract Translated',
+                'Comments',
+                'Note',
+            ],
+            sep='\t',
+        )
+        chosen_content = (
+            content[content['Interest'] == 'chosen']
+            if not include_filtered
+            else content
+        )
+        if len(chosen_content) == 0:
+            return None
+        # 格式化时间
+        chosen_content.loc[:, 'First Submitted Date'] = pd.to_datetime(
+            chosen_content['First Submitted Date'], format='%Y-%m-%d'
+        )
+        chosen_content.loc[:, 'First Announced Date'] = pd.to_datetime(
+            chosen_content['First Announced Date'], format='%Y-%m-%d'
+        )
+        json_data = json.loads(
+            chosen_content.to_json(orient='records', force_ascii=False, indent=2)
+        )
+        for record in json_data:
+            if 'Categories' in record:
+                record['Categories'] = record['Categories'].split(',')
+            if 'Arxiv' in record:
+                record['Arxiv'] = {'link': record['Arxiv'], 'text': record['Arxiv']}
+            if 'PapersCool' in record:
+                record['PapersCool'] = {
+                    'link': record['PapersCool'],
+                    'text': record['PapersCool'],
+                }
+
+        data = []
+        for record in json_data:
+            data.append({'fields': record})
+        return json.dumps({'records': data}, ensure_ascii=False).encode('utf-8')
+
+    def post_data(self, app_token, table_id, json_data):
+        '''此函数用于向 Bitable 中的表格推送数据
+        Ref. https://open.feishu.cn/document/server-docs/docs/bitable-v1/app-table-data/create
+        '''
+        self.update_tenant_access_token()
+        url = f'https://open.feishu.cn/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_create'
+        headers = {
+            'Authorization': f'Bearer {self.token}',
+            'Content-Type': 'application/json; charset=utf-8',
+        }
+        try:
+            response = requests.post(url, headers=headers, data=json_data)
+            result = response.json()
+            if result.get('code') != 0:
+                self.console.log(f'[bold red]Push data failed: {result.get("msg")}')
+                self.console.print_exception()
+            else:
+                return result
+        except Exception as e:
+            self.console.log(f'[bold red]Push data failed: {str(e)}')
+            self.console.print_exception()
+
+        return None
+
+    def to_feishu(self, csv_name, userid, include_filtered=False):
+        '''此函数用于读取 CSV 数据，判断是否存在多维表格并推送到多维表格之中'''
+        csv_basename = os.path.basename(csv_name)
+        basename = os.path.splitext(csv_basename)[0]
+        year, month, day = basename.split('-')
+
+        # format data
+        data = self.format_data(csv_name, include_filtered)
+        if data is None:
+            self.console.log(f'[bold red]No data to push to Feishu')
+            return
+
+        if userid not in self.personal_cfg or year not in self.personal_cfg.get(userid):
+            bitable_create_reponse = self.create_bitable(f'arXiv-文献库-{year}')
+            bitable_token = (
+                bitable_create_reponse.get('data').get('app').get('app_token')
+            )
+            default_table_id = (
+                bitable_create_reponse.get('data').get('app').get('default_table_id')
+            )
+            # 转让多维表格所有权
+            self.transfer_owner(bitable_token, userid)
+            # 创建当前月份的数据表
+            create_table = self.create_table(bitable_token, month)
+            table_id = create_table.get('data').get('table_id')
+            self.create_kanban(bitable_token, table_id)
+            self.delete_table(bitable_token, default_table_id)
+            # Update personal_cfg
+            self.personal_cfg[userid] = {
+                year: {
+                    'bitable_token': bitable_token,
+                    "tables_id": {month: table_id},
+                }
+            }
+
+            with open(self.personal_cfg_fname, 'w') as f:
+                json.dump(self.personal_cfg, f, indent=2, ensure_ascii=False)
+        else:
+            bitable_token = self.personal_cfg.get(userid).get(year).get('bitable_token')
+            tables = self.list_bitable_tables(bitable_token)
+            # 获取表格 ID
+            table_id = None
+            if tables:
+                for item in tables.get('data').get('items'):
+                    if item.get('name') == month:
+                        table_id = item.get('table_id')
+                        break
+            if not table_id:
+                create_table = self.create_table(bitable_token, month)
+                if create_table:
+                    table_id = create_table.get('data').get('table_id')
+                    self.create_kanban(bitable_token, table_id)
+            # Update personal_cfg
+            self.personal_cfg[userid][year]['tables_id'][month] = table_id
+            with open(self.personal_cfg_fname, 'w') as f:
+                json.dump(self.personal_cfg, f, indent=2, ensure_ascii=False)
+
+        self.post_data(bitable_token, table_id, data)
+        self.console.log(f'[bold green]Push data to Feishu success')


### PR DESCRIPTION
- 添加推送到飞书多维表格的代码。
- 添加一个 main.py 文件。用于查询昨日发布且感兴趣的论文，且可以自动推送到飞书多维表格。

**说明**：飞书多维表格的推送需要先创建一个飞书机器人，相关内容可参考：[飞书机器人开发指南](https://open.feishu.cn/document/client-docs/bot-v3/bot-overview)